### PR TITLE
Fix differentiable hashable default implementation2

### DIFF
--- a/Sources/ContentIdentifiable.swift
+++ b/Sources/ContentIdentifiable.swift
@@ -10,7 +10,7 @@ public protocol ContentIdentifiable {
 public extension ContentIdentifiable where Self: Hashable {
     /// The `self` value as an identifier for difference calculation.
     @inlinable
-    var differenceIdentifier: Self {
-        return self
+    var differenceIdentifier: Int {
+        return hashValue
     }
 }

--- a/Tests/AlgorithmTest.swift
+++ b/Tests/AlgorithmTest.swift
@@ -245,14 +245,16 @@ extension AlgorithmTestCase {
 
     func testSameHashValue() {
         struct A: Hashable, Differentiable {
-            let actualValue: Int
+            let id: Int
+            let actualValue: String
 
-            init(_ actualValue: Int) {
+            init(_ id: Int, _ actualValue: String) {
+                self.id = id
                 self.actualValue = actualValue
             }
 
             func hash(into hasher: inout Hasher) {
-                hasher.combine(0)
+                hasher.combine(id)
             }
 
             func isContentEqual(to source: A) -> Bool {
@@ -262,21 +264,25 @@ extension AlgorithmTestCase {
 
         let section = 0
 
-        let source = [A(0), A(1)]
-        let target = [A(0), A(2)]
-
+        let source = [A(0, "a"), A(1, "b"), A(2, "c")]
+        let target = [A(0, "a"), A(1, "c"), A(3, "c")]
+        
         XCTAssertExactDifferences(
             source: source,
             target: target,
             section: section,
             expected: [
                 Changeset(
-                    data: [A(0)],
-                    elementDeleted: [ElementPath(element: 1, section: section)]
+                    data: [A(0, "a"), A(1, "c"), A(2, "c")],
+                    elementUpdated: [ElementPath(element: 1, section: 0)]
+                ),
+                Changeset(
+                    data: [A(0, "a"), A(1, "c")],
+                    elementDeleted: [ElementPath(element: 2, section: 0)]
                 ),
                 Changeset(
                     data: target,
-                    elementInserted: [ElementPath(element: 1, section: section)]
+                    elementInserted: [ElementPath(element: 2, section: 0)]
                 )
             ]
         )

--- a/Tests/AlgorithmTest.swift
+++ b/Tests/AlgorithmTest.swift
@@ -266,7 +266,7 @@ extension AlgorithmTestCase {
 
         let source = [A(0, "a"), A(1, "b"), A(2, "c")]
         let target = [A(0, "a"), A(1, "c"), A(3, "c")]
-        
+
         XCTAssertExactDifferences(
             source: source,
             target: target,


### PR DESCRIPTION
## Checklist
- [ ] All tests are passed.  
- [ ] Added tests.  
- [ ] Documented the code using [Xcode markup](https://developer.apple.com/library/mac/documentation/Xcode/Reference/xcode_markup_formatting_ref).  
- [ ] Searched [existing pull requests](https://github.com/ra1028/DifferenceKit/pulls) for ensure not duplicated.  

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Impact on Existing Code
<!--- Tell us the impact on existing code as far as you understand. -->

## Screenshots (if appropriate)
